### PR TITLE
Upsert/v1

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -45,7 +45,6 @@ lazy val core = project
       "com.precog" %% "async-blobstore-core" % managedVersions.value("precog-async-blobstore"),
       "com.precog" %% "async-blobstore-s3" % managedVersions.value("precog-async-blobstore"),
       "com.amazon.redshift" % "redshift-jdbc42" % "1.2.43.1067"),
-//    quasarPluginExtraResolvers := Seq(coursier.MavenRepository("https://s3.amazonaws.com/redshift-maven-repository/release")),
     performMavenCentralSync := false,
     publishAsOSSProject := false,
     libraryDependencies ++= Seq(

--- a/build.sbt
+++ b/build.sbt
@@ -44,13 +44,16 @@ lazy val core = project
       "org.tpolecat" %% "doobie-hikari" % DoobieVersion,
       "com.precog" %% "async-blobstore-core" % managedVersions.value("precog-async-blobstore"),
       "com.precog" %% "async-blobstore-s3" % managedVersions.value("precog-async-blobstore"),
-      "com.amazon.redshift" % "redshift-jdbc4-no-awssdk" % "1.2.10.1009"),
-    quasarPluginExtraResolvers := Seq(coursier.MavenRepository("https://s3.amazonaws.com/redshift-maven-repository/release")),
+      "com.amazon.redshift" % "redshift-jdbc42" % "1.2.43.1067"),
+//    quasarPluginExtraResolvers := Seq(coursier.MavenRepository("https://s3.amazonaws.com/redshift-maven-repository/release")),
     performMavenCentralSync := false,
     publishAsOSSProject := false,
     libraryDependencies ++= Seq(
+      "com.github.tototoshi" %% "scala-csv" % "1.3.6" % Test,
       "org.specs2" %% "specs2-core" % SpecsVersion % Test,
       "com.precog" %% "quasar-foundation" % managedVersions.value("precog-quasar"),
       "com.precog" %% "quasar-foundation" % managedVersions.value("precog-quasar") % Test classifier "tests",
+      "com.precog" %% "quasar-foundation" % managedVersions.value("precog-quasar") % "test->test" classifier "tests",
+      "com.precog" %% "quasar-connector"  % managedVersions.value("precog-quasar"),
       "org.specs2" %% "specs2-scalacheck" % SpecsVersion % Test))
   .enablePlugins(AutomateHeaderPlugin, QuasarPlugin)

--- a/core/src/main/scala/quasar/destination/redshift/ColumnTypesNotSupported.scala
+++ b/core/src/main/scala/quasar/destination/redshift/ColumnTypesNotSupported.scala
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2020 Precog Data
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.destination.redshift
+
+import slamdata.Predef._
+
+import cats.data.NonEmptyList
+
+import quasar.api.ColumnType
+
+final case class ColumnTypesNotSupported(types: NonEmptyList[ColumnType.Scalar]) extends RuntimeException(
+    s"The redshift destination does not support the following column types: ${types.toList.distinct.mkString(", ")}")

--- a/core/src/main/scala/quasar/destination/redshift/Event.scala
+++ b/core/src/main/scala/quasar/destination/redshift/Event.scala
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2020 Precog Data
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.destination.redshift
+
+import slamdata.Predef._
+
+import quasar.connector._
+
+import cats.effect.Concurrent
+import cats.effect.concurrent.Ref
+import cats.implicits._
+
+import fs2.{Pipe, Stream, Chunk}
+import fs2.concurrent.Queue
+
+sealed trait Event[+F[_], +A]
+
+object Event {
+  type Nothing1[A] = Nothing
+
+  final case class Commit[A](value: A) extends Event[Nothing1, A]
+  final case class Create[F[_]](value: Stream[F, Byte]) extends Event[F, Nothing]
+  final case class Delete(value: IdBatch) extends Event[Nothing1, Nothing]
+
+  def fromDataEvent[F[_]: Concurrent, A]: Pipe[F, DataEvent[Byte, A], Event[F, A]] = {
+    def flush(elqRef: Ref[F, Option[Queue[F, Option[Chunk[Byte]]]]], resQ: Queue[F, Option[Event[F, A]]]): F[Unit] =
+      elqRef.get.flatMap(_.traverse { q =>
+        // When there is a queue (we're collecting inner stream)
+        // Stop collecting
+        q.enqueue1(None)
+      }) >>
+      // notify we're not collecting
+      elqRef.set(None)
+
+    def go(
+        inp: Stream[F, DataEvent[Byte, A]],
+        // result queue
+        resQ: Queue[F, Option[Event[F, A]]],
+        // element queue reference
+        elqRef: Ref[F, Option[Queue[F, Option[Chunk[Byte]]]]])
+        : Stream[F, Unit] = inp evalMap {
+      case DataEvent.Create(chunk) => elqRef.get flatMap {
+        case None => for {
+          newQ <- Queue.unbounded[F, Option[Chunk[Byte]]]
+          _ <- newQ.enqueue1(chunk.some)
+          _ <- elqRef.set(newQ.some)
+          _ <- resQ.enqueue1(Event.Create(newQ.dequeue.unNoneTerminate.flatMap(Stream.chunk)).some)
+        } yield ()
+        case Some(q) =>
+          q.enqueue1(chunk.some)
+      }
+      case DataEvent.Delete(ids) =>
+        flush(elqRef, resQ) >>
+        resQ.enqueue1(Event.Delete(ids).some)
+      case DataEvent.Commit(offset) =>
+        flush(elqRef, resQ) >>
+        resQ.enqueue1(Event.Commit(offset).some)
+    }
+
+    inp => for {
+      resQ <- Stream.eval(Queue.bounded[F, Option[Event[F, A]]](256))
+      elqRef <- Stream.eval(Ref.of[F, Option[Queue[F, Option[Chunk[Byte]]]]](None))
+      results <- resQ.dequeue.unNoneTerminate.concurrently {
+        val inpWithFinalizer = inp.onFinalize {
+          elqRef.get.flatMap(_.traverse_(_.enqueue1(None))) >>
+          resQ.enqueue1(None)
+        }
+
+        go(inpWithFinalizer, resQ, elqRef)
+      }
+    } yield results
+  }
+}

--- a/core/src/main/scala/quasar/destination/redshift/Flow.scala
+++ b/core/src/main/scala/quasar/destination/redshift/Flow.scala
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2020 Precog Data
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.destination.redshift
+
+import slamdata.Predef._
+
+import quasar.api.{Column, ColumnType}
+import quasar.api.push.OffsetKey
+import quasar.api.resource._
+import quasar.connector._
+import quasar.connector.destination.{ResultSink, WriteMode}, ResultSink.{UpsertSink, AppendSink}
+import quasar.connector.render.RenderConfig
+
+import cats.data._
+import cats.effect.{Concurrent, Resource}
+import cats.implicits._
+
+import fs2.{Stream, Pipe, Chunk}
+
+import skolems.∀
+
+private[redshift] trait Flow[F[_]] {
+  def ingest: Pipe[F, Byte, Unit]
+  def delete(ids: IdBatch): Stream[F, Unit]
+}
+
+object Flow {
+  private type FlowColumn = Column[ColumnType.Scalar]
+
+  sealed trait Args {
+    def path: ResourcePath
+    def columns: NonEmptyList[FlowColumn]
+    def writeMode: WriteMode
+    def idColumn: Option[Column[_]]
+  }
+
+  object Args {
+    def ofCreate(p: ResourcePath, cs: NonEmptyList[FlowColumn]): Args = new Args {
+      def path = p
+      def columns = cs
+      def writeMode = WriteMode.Replace
+      def idColumn = None
+    }
+
+    def ofUpsert(args: UpsertSink.Args[ColumnType.Scalar]): Args = new Args {
+      def path = args.path
+      def columns = args.columns
+      def writeMode = args.writeMode
+      def idColumn = args.idColumn.some
+    }
+
+    def ofAppend(args: AppendSink.Args[ColumnType.Scalar]): Args = new Args {
+      def path = args.path
+      def columns = args.columns
+      def writeMode = args.writeMode
+      def idColumn = args.pushColumns.primary
+    }
+  }
+
+  trait Sinks[F[_]] {
+
+    type Consume[E[_], A] =
+      Pipe[F, E[OffsetKey.Actual[A]], OffsetKey.Actual[A]]
+
+    def flowR(args: Args): Resource[F, Flow[F]]
+
+    val render: RenderConfig[Byte]
+
+    def flowSinks(implicit F: Concurrent[F]): NonEmptyList[ResultSink[F, ColumnType.Scalar]] =
+      NonEmptyList.of(ResultSink.create(create), ResultSink.upsert(upsert), ResultSink.append(append))
+
+    private def create(path: ResourcePath, cols: NonEmptyList[FlowColumn])
+        : (RenderConfig[Byte], Pipe[F, Byte, Unit]) = {
+      val args = Args.ofCreate(path, cols)
+      (render, in => for {
+        flow <- Stream.resource(flowR(args))
+        _ <- Stream.emit(Event.Create(in)).through(ingest[Unit](flow))
+      } yield ())
+    }
+
+    private def upsert(upsertArgs: UpsertSink.Args[ColumnType.Scalar])(implicit F: Concurrent[F])
+        : (RenderConfig[Byte], ∀[Consume[DataEvent[Byte, *], *]]) = {
+      val args = Args.ofUpsert(upsertArgs)
+      val consume = ∀[Consume[DataEvent[Byte, *], *]](upsertPipe(args))
+      (render, consume)
+    }
+
+    private def append(appendArgs: AppendSink.Args[ColumnType.Scalar])(implicit F: Concurrent[F])
+        : (RenderConfig[Byte], ∀[Consume[AppendEvent[Byte, *], *]]) = {
+      val args = Args.ofAppend(appendArgs)
+      val consume = ∀[Consume[AppendEvent[Byte, *], *]](upsertPipe(args))
+      (render, consume)
+    }
+
+    private def upsertPipe[A](args: Args)(implicit F: Concurrent[F])
+        : Pipe[F, DataEvent[Byte, OffsetKey.Actual[A]], OffsetKey.Actual[A]] = { events =>
+      for {
+        flow <- Stream.resource(flowR(args))
+        offset <- events
+          .through(Event.fromDataEvent[F, OffsetKey.Actual[A]])
+          .through(ingest[OffsetKey.Actual[A]](flow))
+      } yield offset
+    }
+
+    private def ingest[A](flow: Flow[F]): Pipe[F, Event[F, A], A] = { events =>
+      def handleEvent: Pipe[F, Event[F, A], Option[A]] = _ flatMap {
+        case Event.Create(stream) =>
+          flow.ingest(stream).mapChunks(_ => Chunk(none[A]))
+        case Event.Delete(ids) =>
+          flow.delete(ids).mapChunks(_ => Chunk(none[A]))
+        case Event.Commit(offset) =>
+          Stream.emit(offset.some)
+      }
+
+      events.through(handleEvent).unNone
+    }
+  }
+}

--- a/core/src/main/scala/quasar/destination/redshift/RedshiftDestination.scala
+++ b/core/src/main/scala/quasar/destination/redshift/RedshiftDestination.scala
@@ -16,223 +16,33 @@
 
 package quasar.destination.redshift
 
-import scala.{Stream => _, _}
-import scala.Predef._
-
-import quasar.api.{Column, ColumnType}
+import quasar.api.ColumnType
 import quasar.api.destination.DestinationType
-import quasar.api.resource._
-import quasar.blobstore.paths.{BlobPath, PathElem}
-import quasar.blobstore.s3.{
-  AccessKey,
-  Bucket,
-  SecretKey,
-  Region
-}
 import quasar.blobstore.services.{DeleteService, PutService}
-import quasar.connector.{MonadResourceErr, ResourceError}
+import quasar.connector.MonadResourceErr
 import quasar.connector.destination.{LegacyDestination, ResultSink}
-import quasar.connector.render.RenderConfig
 
-import cats.data.{NonEmptyList, ValidatedNel}
-import cats.effect.{ConcurrentEffect, ContextShift, Sync, Timer}
+import cats.data.NonEmptyList
+import cats.effect._
 import cats.implicits._
 
 import doobie._
-import doobie.implicits._
-
-import fs2.{compression, Pipe, Stream}
-
-import org.slf4s.Logging
-
-import java.time.format.DateTimeFormatter
-import java.util.UUID
-
-import shims._
 
 final class RedshiftDestination[F[_]: ConcurrentEffect: ContextShift: MonadResourceErr: Timer](
   deleteService: DeleteService[F],
   put: PutService[F],
   config: RedshiftConfig,
-  xa: Transactor[F]) extends LegacyDestination[F] with Logging {
+  xa: Transactor[F]) extends LegacyDestination[F] with Flow.Sinks[F] {
 
-  private val RedshiftRenderConfig = RenderConfig.Csv(
-    includeHeader = false,
-    includeBom = false,
-    offsetDateTimeFormat = DateTimeFormatter.ofPattern("uuuu-MM-dd HH:mm:ssx"),
-    // RedShift doesn't have time-only data types so we fake it by prepending an arbitrary date (1900-01-01)
-    offsetTimeFormat = DateTimeFormatter.ofPattern("'1900-01-01' HH:mm:ssx"),
-    localDateTimeFormat = DateTimeFormatter.ofPattern("uuuu-MM-dd HH:mm:ss"),
-    localTimeFormat = DateTimeFormatter.ofPattern("'1900-01-01' HH:mm:ss"),
-    localDateFormat = DateTimeFormatter.ofPattern("uuuu-MM-dd"))
+  val render = RedshiftDestinationModule.RedshiftRenderConfig
+
+  // If we ever wanted to make transactor initialized by queries we could modify `xa` to be `Resource[F, Transactor[F]]`
+  def flowR(args: Flow.Args): Resource[F, Flow[F]] =
+    RedshiftFlow(deleteService, put, config, xa.pure[Resource[F, *]], args)
 
   def destinationType: DestinationType =
     RedshiftDestinationModule.destinationType
 
   def sinks: NonEmptyList[ResultSink[F, ColumnType.Scalar]] =
-    NonEmptyList.one(csvSink)
-
-  private val csvSink: ResultSink[F, ColumnType.Scalar] =
-    ResultSink.create[F, ColumnType.Scalar, Byte] { (path, columns) =>
-      val pipe: Pipe[F, Byte, Unit] = bytes => Stream.force(for {
-        cols <- Sync[F].fromEither(ensureValidColumns(columns).leftMap(new RuntimeException(_)))
-
-        tableName <- ensureValidTableName(path)
-
-        compressed = bytes.through(compression.gzip(bufferSize = 1024 * 32))
-
-        suffix <- Sync[F].delay(UUID.randomUUID().toString)
-
-        freshName = s"reform-$suffix.gz"
-
-        uploadPath = BlobPath(List(PathElem(freshName)))
-
-        _ <- put((uploadPath, compressed))
-
-        pushF = push(tableName, uploadPath, config.uploadBucket.bucket, cols, config.authorization)
-
-        pushS = Stream.eval(pushF).onFinalize(deleteFile(uploadPath))
-
-      } yield pushS)
-
-      (RedshiftRenderConfig, pipe)
-  }
-
-  private def deleteFile(path: BlobPath): F[Unit] =
-    deleteService(path).void
-
-  private def push(
-    tableName: String,
-    path: BlobPath,
-    bucket: Bucket,
-    cols: NonEmptyList[Fragment],
-    authorization: Authorization)
-      : F[Unit] = {
-    val dropQuery = dropTableQuery(tableName).update
-
-    val createQuery = createTableQuery(tableName, cols).update
-
-    val copyQuery =
-      copyTableQuery(
-        tableName,
-        bucket,
-        path,
-        authorization).update
-
-    val copyQueryRedacted =
-      copyTableQuery(
-        tableName,
-        bucket,
-        path,
-        redactAuth(authorization)).update
-
-    for {
-      _ <- debug(s"Drop table query: ${dropQuery.sql}")
-
-      _ <- debug(s"Create table query: ${createQuery.sql}")
-
-      _ <- debug(s"Copy table query: ${copyQueryRedacted.sql}")
-
-      _ <- (dropQuery.run *> createQuery.run *> copyQuery.run).transact(xa)
-
-      _ <- debug("Finished table copy")
-
-    } yield ()
-  }
-
-  private def ensureValidColumns(columns: NonEmptyList[Column[ColumnType.Scalar]])
-      : Either[String, NonEmptyList[Fragment]] =
-    columns.traverse(mkColumn(_)).toEither.leftMap(errs =>
-      s"Some column types are not supported: ${mkErrorString(errs)}")
-
-  private def ensureValidTableName(r: ResourcePath): F[String] =
-    r match {
-      case file /: ResourcePath.Root => escape(file).pure[F]
-      case _ => MonadResourceErr[F].raiseError(ResourceError.notAResource(r))
-    }
-
-  def escape(ident: String): String = {
-    val escaped =
-      ident
-        .replace("\\", "")
-        .replace(" ", "_")
-        .replace("\"", "\"\"")
-
-    s""""$escaped""""
-  }
-
-  def removeSingleQuotes(str: String): String =
-    str.replace("'", "")
-
-  private def copyTableQuery(
-    tableName: String,
-    bucket: Bucket,
-    blob: BlobPath,
-    auth: Authorization)
-      : Fragment =
-    fr"COPY" ++
-       Fragment.const(tableName) ++
-       fr"FROM" ++
-       s3PathFragment(bucket, blob) ++
-       authFragment(auth) ++
-       fr"CSV" ++
-       fr"GZIP" ++
-       fr"EMPTYASNULL"
-
-  private def s3PathFragment(bucket: Bucket, prefix: BlobPath): Fragment = {
-    val path = prefix.path.map(_.value).intercalate("/")
-
-    Fragment.const(s"'s3://${bucket.value}/$path'")
-  }
-
-  private def authFragment(auth: Authorization): Fragment = auth match {
-    case Authorization.RoleARN(arn0, Region(region0)) => {
-      val arn = removeSingleQuotes(arn0)
-      val region = removeSingleQuotes(region0)
-
-      Fragment.const(s"iam_role '$arn' region '$region'")
-    }
-    case Authorization.Keys(AccessKey(accessKey0), SecretKey(secretKey0), Region(region0)) => {
-      val accessKey = removeSingleQuotes(accessKey0)
-      val secretKey = removeSingleQuotes(secretKey0)
-      val region = removeSingleQuotes(region0)
-
-      Fragment.const(s"access_key_id '$accessKey' secret_access_key '$secretKey' region '$region'")
-    }
-  }
-
-  private def createTableQuery(tableName: String, columns: NonEmptyList[Fragment]): Fragment =
-    fr"CREATE TABLE" ++ Fragment.const(tableName) ++
-      Fragments.parentheses(columns.intercalate(fr","))
-
-  private def dropTableQuery(tableName: String): Fragment =
-    fr"DROP TABLE IF EXISTS" ++ Fragment.const(tableName)
-
-  private def mkErrorString(errs: NonEmptyList[ColumnType.Scalar]): String =
-    errs
-      .map(err => s"Column of type ${err.show} is not supported by Redshift")
-      .intercalate(", ")
-
-  private def mkColumn(c: Column[ColumnType.Scalar])
-      : ValidatedNel[ColumnType.Scalar, Fragment] =
-    columnTypeToRedshift(c.tpe).map(Fragment.const(escape(c.name)) ++ _)
-
-  private def columnTypeToRedshift(ct: ColumnType.Scalar)
-      : ValidatedNel[ColumnType.Scalar, Fragment] =
-    ct match {
-      case ColumnType.Null => fr0"SMALLINT".validNel
-      case ColumnType.Boolean => fr0"BOOLEAN".validNel
-      case lt @ ColumnType.LocalTime => fr0"TIMESTAMP".validNel
-      case ot @ ColumnType.OffsetTime => fr0"TIMESTAMPTZ".validNel
-      case ColumnType.LocalDate => fr0"DATE".validNel
-      case od @ ColumnType.OffsetDate => od.invalidNel
-      case ColumnType.LocalDateTime => fr0"TIMESTAMP".validNel
-      case ColumnType.OffsetDateTime => fr0"TIMESTAMPTZ".validNel
-      case i @ ColumnType.Interval => i.invalidNel
-      case ColumnType.Number => fr0"DECIMAL".validNel
-      case ColumnType.String => fr0"VARCHAR(4096)".validNel
-    }
-
-  private def debug(msg: String): F[Unit] =
-    Sync[F].delay(log.debug(msg))
+    flowSinks
 }

--- a/core/src/main/scala/quasar/destination/redshift/RedshiftFlow.scala
+++ b/core/src/main/scala/quasar/destination/redshift/RedshiftFlow.scala
@@ -1,0 +1,262 @@
+/*
+ * Copyright 2020 Precog Data
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.destination.redshift
+
+import slamdata.Predef._
+
+import quasar.api.{Column, ColumnType}
+import quasar.api.resource._
+import quasar.blobstore.paths.{BlobPath, PathElem}
+import quasar.blobstore.s3.{
+  AccessKey,
+  Bucket,
+  SecretKey,
+  Region
+}
+import quasar.blobstore.services.{DeleteService, PutService}
+import quasar.connector._
+import quasar.connector.destination.WriteMode
+
+import cats.Applicative
+import cats.data.{NonEmptyList, ValidatedNel}
+import cats.effect._
+import cats.effect.concurrent.Ref
+import cats.implicits._
+
+import doobie._
+import doobie.implicits._
+
+import fs2.{compression, Pipe, Stream}
+
+import org.slf4s.Logging
+
+import java.util.UUID
+
+import shims._
+
+final class RedshiftFlow[F[_]: ConcurrentEffect: ContextShift: Timer: MonadResourceErr](
+    deleteService: DeleteService[F],
+    putService: PutService[F],
+    config: RedshiftConfig,
+    name: String,
+    xa: Transactor[F],
+    writeModeRef: Ref[F, WriteMode],
+    args: Flow.Args)
+    extends Flow[F] with Logging {
+
+  def delete(ids: IdBatch): Stream[F, Unit] = args.idColumn.traverse_ { idCol =>
+    val strs: Array[String] = ids match {
+      case IdBatch.Strings(values, _) => values.map(x => "'" + x.replace("'", "''") + "'")
+      case IdBatch.Longs(values, _) => values.map(_.toString)
+      case IdBatch.Doubles(values, _) => values.map(_.toString)
+      case IdBatch.BigDecimals(values, _) => values.map(_.toString)
+    }
+
+    // The limit is 16Mb, we split on 4Mb, no need to count `DELETE FROM`
+    @scala.annotation.tailrec
+    def group(inp: Array[String], accum: (Int, List[List[String]]), len: Int, ix: Int)
+        : List[List[String]] =
+      if (ix >= len) accum._2
+      else {
+        val elem = inp(ix)
+        val elemSize = elem.getBytes.length
+        val resultSize = accum._1 + elemSize
+        val newAccum = if (resultSize >= RedshiftFlow.DeleteQueryLimit) {
+          (elemSize, List(elem) :: accum._2)
+        }
+        else (resultSize, accum._2 match {
+          case hd :: tail => (elem :: hd) :: tail
+          case other => List(List(elem))
+        })
+
+        group(inp, newAccum, len, ix + 1)
+      }
+
+    val grouped = group(strs, (0, List()), strs.length, 0)
+
+    val deleteFromFragment =
+      fr"DELETE FROM" ++
+      Fragment.const(name) ++
+      fr"WHERE" ++
+      Fragment.const(RedshiftFlow.escape(idCol.name))
+
+    Stream
+      .emits(grouped)
+      .map({ (x: List[String]) =>
+        deleteFromFragment ++
+        fr"IN" ++
+        Fragments.parentheses(x.map(Fragment.const(_)).intercalate(fr","))
+      })
+      .evalMap({ (fr: Fragment) =>
+        debug[F](s"DELETE QUERY: ${fr.update.sql}") >>
+        fr.update.run.transact(xa).void
+      })
+  }
+
+  def ingest: Pipe[F, Byte, Unit] = { inp =>
+    Stream.resource {
+      for {
+        cols <- Resource.liftF { args.columns.traverse(mkColumn).fold(
+          invalid => Sync[F].raiseError(ColumnTypesNotSupported(invalid)),
+          _.pure[F])
+        }
+        uploaded <- stageFile(inp)
+        writeMode <- Resource.liftF(writeModeRef.get)
+        _ <- writeMode match {
+          case WriteMode.Replace => Resource.liftF {
+            createNewTable(cols).transact(xa) >>
+            writeModeRef.set(WriteMode.Append)
+          }
+          case WriteMode.Append => ().pure[Resource[F, *]]
+        }
+        _ <- Resource.liftF {
+          copyInto(uploaded, config.uploadBucket.bucket, args.columns, config.authorization)
+        }
+      } yield ()
+    }
+  }
+
+  private def copyInto(
+      blob: BlobPath,
+      bucket: Bucket,
+      cols: NonEmptyList[Column[_]],
+      authorization: Authorization): F[Unit] = {
+    val columnsFragment =
+      Fragments.parentheses(cols.map(x => Fragment.const(RedshiftFlow.escape(x.name))).intercalate(fr","))
+
+    val s3PathFragment = {
+      val path = blob.path.map(_.value).intercalate("/")
+      Fragment.const(s"'s3://${bucket.value}/$path'")
+    }
+
+    val authFragment: Authorization => Fragment = {
+      case Authorization.RoleARN(arn0, Region(region0)) =>
+        val arn = removeSingleQuotes(arn0)
+        val region = removeSingleQuotes(region0)
+        Fragment.const(s"iam_role '$arn' region '$region'")
+      case Authorization.Keys(AccessKey(accessKey0), SecretKey(secretKey0), Region(region0)) =>
+        val accessKey = removeSingleQuotes(accessKey0)
+        val secretKey = removeSingleQuotes(secretKey0)
+        val region = removeSingleQuotes(region0)
+        Fragment.const(s"access_key_id '$accessKey' secret_access_key '$secretKey' region '$region'")
+    }
+
+    val copyFragment: Authorization => Fragment = { a =>
+      fr"COPY" ++
+      Fragment.const(name) ++
+      columnsFragment ++
+      fr"FROM" ++
+      s3PathFragment ++
+      authFragment(authorization) ++
+      fr"CSV" ++
+      fr"GZIP" ++
+      fr"EMPTYASNULL"
+    }
+
+    debug[F](s"COPY QUERY: ${copyFragment(redactAuth(authorization)).update.sql}") >>
+    copyFragment(authorization).update.run.void.transact(xa)
+  }
+
+  private def removeSingleQuotes(inp: String): String =
+    inp.replace("'", "")
+
+  private def createNewTable(columns: NonEmptyList[Fragment]): ConnectionIO[Unit] = {
+    dropTableIfExists >>
+    createTable(columns)
+  }
+
+  private def dropTableIfExists: ConnectionIO[Unit] = {
+    val fragment = fr"DROP TABLE IF EXISTS" ++ Fragment.const(name)
+    debug[ConnectionIO](s"DROP QUERY: ${fragment.update.sql}") >>
+    fragment.update.run.void
+  }
+
+  private def createTable(columns: NonEmptyList[Fragment]): ConnectionIO[Unit] = {
+    val fragment =
+      fr"CREATE TABLE" ++ Fragment.const(name) ++ Fragments.parentheses(columns.intercalate(fr","))
+    debug[ConnectionIO](s"CREATE QUERY: ${fragment.update.sql}") >>
+    fragment.update.run.void
+  }
+
+  private def stageFile(bytes: Stream[F, Byte]): Resource[F, BlobPath] = {
+    val compressed = bytes.through(compression.gzip(bufferSize = 1024 * 32))
+
+    val make = for {
+      suffix <- Sync[F].delay(UUID.randomUUID().toString)
+      freshName = s"reform-$suffix.gz"
+      uploadPath = BlobPath(List(PathElem(freshName)))
+      _ <- putService((uploadPath, compressed))
+    } yield uploadPath
+
+    Resource.make(make)(deleteService(_).void)
+  }
+
+  private def mkColumn(c: Column[ColumnType.Scalar])
+      : ValidatedNel[ColumnType.Scalar, Fragment] =
+    columnTypeToRedshift(c.tpe).map(Fragment.const(RedshiftFlow.escape(c.name)) ++ _)
+
+  private def columnTypeToRedshift(ct: ColumnType.Scalar)
+      : ValidatedNel[ColumnType.Scalar, Fragment] =
+    ct match {
+      case ColumnType.Null => fr0"SMALLINT".validNel
+      case ColumnType.Boolean => fr0"BOOLEAN".validNel
+      case lt @ ColumnType.LocalTime => fr0"TIMESTAMP".validNel
+      case ot @ ColumnType.OffsetTime => fr0"TIMESTAMPTZ".validNel
+      case ColumnType.LocalDate => fr0"DATE".validNel
+      case od @ ColumnType.OffsetDate => od.invalidNel
+      case ColumnType.LocalDateTime => fr0"TIMESTAMP".validNel
+      case ColumnType.OffsetDateTime => fr0"TIMESTAMPTZ".validNel
+      case i @ ColumnType.Interval => i.invalidNel
+      case ColumnType.Number => fr0"DECIMAL(21, 6)".validNel
+      case ColumnType.String => fr0"VARCHAR(4096)".validNel
+    }
+
+  private def debug[G[_]: Sync](msg: String): G[Unit] =
+    Sync[G].delay(log.debug(msg))
+}
+
+object RedshiftFlow {
+  val DeleteQueryLimit = 4 * 1024 * 1024
+
+  // If we ever wanted to make transactor initialized by queries we could use
+  def apply[F[_]: ConcurrentEffect: ContextShift: Timer: MonadResourceErr](
+      deleteService: DeleteService[F],
+      putService: PutService[F],
+      config: RedshiftConfig,
+      rxa: Resource[F, Transactor[F]],
+      args: Flow.Args)
+      : Resource[F, Flow[F]] = for {
+    xa <- rxa
+    tableName <- Resource.liftF(ensureValidTableName[F](args.path))
+    writeModeRef <- Resource.liftF(Ref.of[F, WriteMode](args.writeMode))
+  } yield new RedshiftFlow(deleteService, putService, config, tableName, xa, writeModeRef, args)
+
+  private def ensureValidTableName[F[_]: Applicative: MonadResourceErr](r: ResourcePath): F[String] = r match {
+    case file /: ResourcePath.Root => escape(file).pure[F]
+    case _ => MonadResourceErr[F].raiseError(ResourceError.notAResource(r))
+  }
+
+  def escape(ident: String): String = {
+    val escaped =
+      ident
+        .replace("\\", "")
+        .replace(" ", "_")
+        .replace("\"", "\"\"")
+
+    s""""$escaped""""
+  }
+}

--- a/core/src/main/scala/quasar/destination/redshift/RedshiftFlow.scala
+++ b/core/src/main/scala/quasar/destination/redshift/RedshiftFlow.scala
@@ -232,7 +232,6 @@ final class RedshiftFlow[F[_]: ConcurrentEffect: ContextShift: Timer: MonadResou
 object RedshiftFlow {
   val DeleteQueryLimit = 4 * 1024 * 1024
 
-  // If we ever wanted to make transactor initialized by queries we could use
   def apply[F[_]: ConcurrentEffect: ContextShift: Timer: MonadResourceErr](
       deleteService: DeleteService[F],
       putService: PutService[F],

--- a/core/src/test/scala/quasar/destination/redshift/CsvSupport.scala
+++ b/core/src/test/scala/quasar/destination/redshift/CsvSupport.scala
@@ -1,0 +1,339 @@
+/*
+ * Copyright 2020 Precog Data
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.destination.redshift
+
+import slamdata.Predef._
+
+import cats.ApplicativeError
+import cats.data.NonEmptyList
+import cats.effect.Async
+import cats.implicits._
+
+import com.github.tototoshi.csv._
+
+import cats.implicits._
+import fs2._
+
+import java.io.ByteArrayOutputStream
+import java.time._
+
+import qdata.time._
+import quasar.api.{Column, ColumnType}
+import quasar.api.resource.ResourcePath
+import quasar.api.push.{PushColumns, OffsetKey}
+import quasar.connector.{AppendEvent, IdBatch, DataEvent}
+import quasar.connector.destination.ResultSink
+import quasar.connector.render.RenderConfig
+import quasar.connector.destination.{ResultSink, WriteMode => QWriteMode}
+
+import scala.Float
+import scala.collection.immutable.Seq
+
+import shapeless._
+import shapeless.ops.hlist.{Mapper, ToList}
+import shapeless.ops.record.{Keys, Values}
+import shapeless.record._
+
+trait CsvSupport {
+
+  // Must remain in sync with Quasar's CSV output format to be representative.
+  val QuasarCSVFormat: CSVFormat =
+    new CSVFormat {
+      val delimiter = ','
+      val quoteChar = '"'
+      val escapeChar = '"'
+      val lineTerminator = "\r\n"
+      val quoting = QUOTE_MINIMAL
+      val treatEmptyLineAsNil = false
+    }
+
+  sealed trait UpsertEvent[+A] extends Product with Serializable
+  sealed trait Ids extends Product with Serializable
+
+  object Ids {
+    case class StringIds(ids: List[String]) extends Ids
+    case class LongIds(ids: List[Long]) extends Ids
+  }
+
+  object UpsertEvent {
+    case class Create[A](records: List[A]) extends UpsertEvent[A]
+    case class Delete(recordsIds: Ids) extends UpsertEvent[Nothing]
+    case class Commit(value: String) extends UpsertEvent[Nothing]
+  }
+
+  // TODO: handle includeHeader == true
+  def toCsvSink[F[_]: ApplicativeError[?[_], Throwable], P <: Poly1, R <: HList, K <: HList, V <: HList, T <: HList, S <: HList](
+      dst: ResourcePath,
+      sink: ResultSink.CreateSink[F, ColumnType.Scalar, Byte],
+      renderRow: P,
+      records: Stream[F, R])(
+      implicit
+      keys: Keys.Aux[R, K],
+      values: Values.Aux[R, V],
+      getTypes: Mapper.Aux[asColumnType.type, V, T],
+      renderValues: Mapper.Aux[renderRow.type, V, S],
+      ktl: ToList[K, String],
+      stl: ToList[S, String],
+      ttl: ToList[T, ColumnType.Scalar])
+      : Stream[F, Unit] = {
+
+    val go = records.pull.peek1 flatMap {
+      case Some((r, rs)) =>
+        val rkeys = r.keys.toList
+        val rtypes = r.values.map(asColumnType).toList
+        val columns = rkeys.zip(rtypes).map((Column[ColumnType.Scalar] _).tupled)
+        val encoded = rs.through(encodeCsvRecords[F, renderRow.type, R, V, S](renderRow))
+
+        encoded.through(sink.consume(dst, NonEmptyList.fromListUnsafe(columns))._2).pull.echo
+
+      case None => Pull.done
+    }
+
+    go.stream
+  }
+
+  def columnsOf[
+    F[_]: Async, P <: Poly1, R <: HList, K <: HList, V <: HList, T <: HList, S <: HList](
+    events: Stream[F, UpsertEvent[R]],
+    renderRow: P,
+    idColumn: Option[Column[ColumnType.Scalar]])(
+    implicit
+    keys: Keys.Aux[R, K],
+    values: Values.Aux[R, V],
+    getTypes: Mapper.Aux[asColumnType.type, V, T],
+    ktl: ToList[K, String],
+    ttl: ToList[T, ColumnType.Scalar])
+    : Stream[F, List[Column[ColumnType.Scalar]]] = {
+    def go(inp: Stream[F, UpsertEvent[R]]): Pull[F, List[Column[ColumnType.Scalar]], Unit] = inp.pull.uncons1 flatMap {
+      case Some((UpsertEvent.Create(records), tail)) => records.headOption match {
+        case Some(r) =>
+          val rkeys = r.keys.toList
+          val rtypes = r.values.map(asColumnType).toList
+          val columns = rkeys.zip(rtypes).map((Column[ColumnType.Scalar] _).tupled)
+          Pull.output1(columns.filter(c => c.some =!= idColumn)) >> Pull.done
+        case None =>
+          Pull.done
+      }
+      case Some((_, tail)) =>
+        go(tail)
+      case _ =>
+        Pull.done
+
+    }
+    go(events).stream
+  }
+
+  def toAppendCsvSink[F[_]: Async, P <: Poly1, R <: HList, K <: HList, V <: HList, T <: HList, S <: HList](
+      dst: ResourcePath,
+      sink: ResultSink.AppendSink[F, ColumnType.Scalar],
+      idColumn: Option[Column[ColumnType.Scalar]],
+      writeMode: QWriteMode,
+      renderRow: P,
+      events: Stream[F, UpsertEvent[R]])(
+      implicit
+      keys: Keys.Aux[R, K],
+      values: Values.Aux[R, V],
+      getTypes: Mapper.Aux[asColumnType.type, V, T],
+      renderValues: Mapper.Aux[renderRow.type, V, S],
+      ktl: ToList[K, String],
+      stl: ToList[S, String],
+      ttl: ToList[T, ColumnType.Scalar])
+      : Stream[F, OffsetKey.Actual[String]] = {
+
+    val encoded: Stream[F, AppendEvent[Byte, OffsetKey.Actual[String]]] = events flatMap {
+      case UpsertEvent.Create(records) => {
+        Stream.emits(records)
+          .covary[F]
+          .through(
+            encodeCsvRecordsToChunk[F, renderRow.type, R, V, S](renderRow))
+          .map(DataEvent.Create(_))
+      }
+
+      case UpsertEvent.Commit(s) =>
+        Stream(
+          DataEvent.Commit(OffsetKey.Actual.string(s)))
+
+      case UpsertEvent.Delete(_) =>
+        Stream.eval_(Async[F].raiseError(new Exception("AppendSink can't handle delete events")))
+    }
+
+    type Consumed = ResultSink.AppendSink.Result[F] { type A = Byte }
+    for {
+      colList <- columnsOf(events, renderRow, idColumn)
+      cols = idColumn match {
+        case None => PushColumns.NoPrimary(NonEmptyList.fromListUnsafe(colList))
+        case Some(i) => PushColumns.HasPrimary(List(), i, colList)
+      }
+      consumed = sink.consume.apply(
+        ResultSink.AppendSink.Args(dst, cols, writeMode))
+      res <- encoded.through(consumed.asInstanceOf[Consumed].pipe[String])
+    } yield res
+  }
+
+  def toUpsertCsvSink[F[_]: Async, P <: Poly1, R <: HList, K <: HList, V <: HList, T <: HList, S <: HList](
+      dst: ResourcePath,
+      sink: ResultSink.UpsertSink[F, ColumnType.Scalar, Byte],
+      idColumn: Column[ColumnType.Scalar],
+      writeMode: QWriteMode,
+      renderRow: P,
+      events: Stream[F, UpsertEvent[R]])(
+      implicit
+      keys: Keys.Aux[R, K],
+      values: Values.Aux[R, V],
+      getTypes: Mapper.Aux[asColumnType.type, V, T],
+      renderValues: Mapper.Aux[renderRow.type, V, S],
+      ktl: ToList[K, String],
+      stl: ToList[S, String],
+      ttl: ToList[T, ColumnType.Scalar])
+      : Stream[F, OffsetKey.Actual[String]] = {
+
+    val encoded: Stream[F, DataEvent[Byte, OffsetKey.Actual[String]]] = events flatMap {
+      case UpsertEvent.Create(records) => {
+        Stream.emits(records)
+          .covary[F]
+          .through(
+            encodeCsvRecordsToChunk[F, renderRow.type, R, V, S](renderRow))
+          .map(DataEvent.create[Byte, OffsetKey.Actual[String]])
+      }
+
+      case UpsertEvent.Commit(s) =>
+        Stream(
+          DataEvent.Commit(OffsetKey.Actual.string(s)))
+
+      case UpsertEvent.Delete(Ids.StringIds(is)) =>
+        Stream(
+          DataEvent.Delete(IdBatch.Strings(is.toArray, is.length)))
+
+      case UpsertEvent.Delete(Ids.LongIds(is)) =>
+        Stream(
+          DataEvent.Delete(IdBatch.Longs(is.toArray, is.length)))
+    }
+
+    columnsOf(events, renderRow, Some(idColumn)) flatMap { cols =>
+      val (_, pipe) = sink.consume.apply(
+        ResultSink.UpsertSink.Args(dst, idColumn, cols, writeMode))
+
+      encoded.through(pipe[String])
+    }
+  }
+
+  def encodeCsvRecordsToChunk[F[_]: Async, P <: Poly1, R <: HList, V <: HList, S <: HList](
+      renderRow: P)(
+      implicit
+      values: Values.Aux[R, V],
+      render: Mapper.Aux[renderRow.type, V, S],
+      ltl: ToList[S, String])
+      : Pipe[F, R, Chunk[Byte]] =
+    encodeCsvRecords[F, P, R, V, S](renderRow).andThen(bytes =>
+      bytes.chunks.fold(Chunk.empty[Byte])((l, r) => Chunk.concatBytes(Seq(l, r))))
+
+  def encodeCsvRecords[F[_]: ApplicativeError[?[_], Throwable], P <: Poly1, R <: HList, V <: HList, S <: HList](
+      renderRow: P)(
+      implicit
+      values: Values.Aux[R, V],
+      render: Mapper.Aux[renderRow.type, V, S],
+      ltl: ToList[S, String])
+      : Pipe[F, R, Byte] =
+    _.map(_.values.map(renderRow).toList).through(encodeCsvRows[F])
+
+  class renderForCsv(cfg: RenderConfig.Csv) extends Poly1 {
+    implicit val boolCase = at[Boolean](_.toString)
+
+    implicit val localTimeCase = at[LocalTime](_.format(cfg.localTimeFormat))
+    implicit val offsetTimeCase = at[OffsetTime](_.format(cfg.offsetTimeFormat))
+
+    implicit val localDateCase = at[LocalDate](_.format(cfg.localDateFormat))
+    implicit val offsetDateCase = at[OffsetDate](cfg.offsetDateFormat.format)
+
+    implicit val localDateTimeCase = at[LocalDateTime](_.format(cfg.localDateTimeFormat))
+    implicit val offsetDateTimeCase = at[OffsetDateTime](_.format(cfg.offsetDateTimeFormat))
+
+    implicit val dateTimeIntervalCase = at[DateTimeInterval](_.toString)
+
+    implicit val shortCase = at[Short](_.toString)
+    implicit val intCase = at[Int](_.toString)
+    implicit val longCase = at[Long](_.toString)
+    implicit val floatCase = at[Float](_.toString)
+    implicit val doubleCase = at[Double](_.toString)
+    implicit val bigDecCase = at[BigDecimal](_.toString)
+
+    implicit val charCase = at[Char](_.toString)
+    implicit val stringCase = at[String](s => s)
+  }
+
+  object asColumnType extends Poly1 {
+    implicit val boolCase = at[Boolean](_ => ColumnType.Boolean)
+
+    implicit val localTimeCase = at[LocalTime](_ => ColumnType.LocalTime)
+    implicit val offsetTimeCase = at[OffsetTime](_ => ColumnType.OffsetTime)
+
+    implicit val localDateCase = at[LocalDate](_ => ColumnType.LocalDate)
+    implicit val offsetDateCase = at[OffsetDate](_ => ColumnType.OffsetDate)
+
+    implicit val localDateTimeCase = at[LocalDateTime](_ => ColumnType.LocalDateTime)
+    implicit val offsetDateTimeCase = at[OffsetDateTime](_ => ColumnType.OffsetDateTime)
+
+    implicit val dateTimeIntervalCase = at[DateTimeInterval](_ => ColumnType.Interval)
+
+    implicit val shortCase = at[Short](_ => ColumnType.Number)
+    implicit val intCase = at[Int](_ => ColumnType.Number)
+    implicit val longCase = at[Long](_ => ColumnType.Number)
+    implicit val floatCase = at[Float](_ => ColumnType.Number)
+    implicit val doubleCase = at[Double](_ => ColumnType.Number)
+    implicit val bigDecCase = at[BigDecimal](_ => ColumnType.Number)
+
+    implicit val charCase = at[Char](_ => ColumnType.String)
+    implicit val stringCase = at[String](_ => ColumnType.String)
+  }
+
+  ////
+
+  private def encodeCsvRows[F[_]](implicit F: ApplicativeError[F, Throwable])
+      : Pipe[F, Seq[String], Byte] =
+    in => Stream.suspend {
+      val os = new ByteArrayOutputStream
+      val csvWriter = CSVWriter.open(os, "UTF-8")(QuasarCSVFormat)
+
+      def drainBytes: Stream[F, Byte] = {
+        val bs = os.toByteArray
+        os.reset()
+        Stream.chunk(Chunk.bytes(bs))
+      }
+
+      val process: Stream[F, Byte] =
+        for {
+          row <- in
+
+          _ <- Stream.eval(F catchNonFatal {
+            csvWriter.writeRow(row)
+            csvWriter.flush()
+          })
+
+          b <- drainBytes
+        } yield b
+
+      val finish: Stream[F, Byte] =
+        Stream.suspend {
+          csvWriter.close()
+          drainBytes
+        }
+
+      process ++ finish
+    }
+}
+
+object CsvSupport extends CsvSupport

--- a/core/src/test/scala/quasar/destination/redshift/RedshiftDestinationSpec.scala
+++ b/core/src/test/scala/quasar/destination/redshift/RedshiftDestinationSpec.scala
@@ -1,0 +1,745 @@
+/*
+ * Copyright 2020 Precog Data
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.destination.redshift
+
+import slamdata.Predef._
+
+import argonaut._, Argonaut._, ArgonautScalaz._
+
+import cats.data.NonEmptyList
+import cats.effect._
+import cats.implicits._
+
+import doobie._
+import doobie.implicits._
+import doobie.util.Read
+
+import fs2.{Pull, Stream}
+
+import java.time._
+
+import org.specs2.matcher.MatchResult
+import org.specs2.execute.AsResult
+import org.specs2.specification.core.{Fragment => SFragment}
+
+import qdata.time._
+
+import quasar.EffectfulQSpec
+import quasar.api.{Column, ColumnType}
+import quasar.api.destination._
+import quasar.api.push.OffsetKey
+import quasar.api.resource._
+import quasar.contrib.scalaz.MonadError_
+import quasar.connector._
+import quasar.connector.destination._
+
+import scala.util.Random
+import scala.concurrent.ExecutionContext.Implicits.global
+
+import scalaz.-\/
+import scalaz.syntax.show._
+
+import shapeless._
+import shapeless.ops.hlist.{Mapper, ToList}
+import shapeless.ops.record.{Keys, Values}
+import shapeless.record._
+import shapeless.syntax.singleton._
+
+import shims.applicativeToScalaz
+
+object RedshiftDestinationSpec extends EffectfulQSpec[IO] with CsvSupport {
+
+  skipAllIf(!testsEnabled)
+
+  "initialization" should {
+    "fail with malformed config when not decodable" >>* {
+      val cfg = Json("malformed" := true)
+
+      dest(cfg)(r => IO.pure(r match {
+        case Left(DestinationError.MalformedConfiguration(_, c, _)) =>
+          c must_=== jEmptyObject
+
+        case _ => ko("Expected a malformed configuration")
+      }))
+    }
+
+    "fail when unable to connect to database" >>* {
+      val cfg = config(url = "jdbc:redshift://localhost:1234/foobar")
+
+      dest(cfg)(r => IO.unit).attempt.map(_ must beLeft)
+
+    }
+  }
+
+  "seek sinks (upsert and append)" should {
+    "write after commit" >> appendAndUpsert[String :: String :: HNil] { (toOpt, consumer) =>
+      val events =
+        Stream(
+          UpsertEvent.Create(List(
+            ("x" ->> "foo") :: ("y" ->> "bar") :: HNil,
+            ("x" ->> "baz") :: ("y" ->> "qux") :: HNil)),
+          UpsertEvent.Commit("commit1"))
+
+      for {
+        tbl <- freshTableName
+        (values, offsets) <- consumer(tbl, toOpt(Column("x", ColumnType.String)), WriteMode.Replace, events)
+        } yield {
+          values must_== List(
+            "foo" :: "bar" :: HNil,
+            "baz" :: "qux" :: HNil)
+        }
+    }
+
+    "write two chunks with a single commit" >> appendAndUpsert[String :: String :: HNil] { (toOpt, consumer) =>
+      val events =
+        Stream(
+          UpsertEvent.Create(List(
+            ("x" ->> "foo") :: ("y" ->> "bar") :: HNil)),
+          UpsertEvent.Create(List(
+            ("x" ->> "baz") :: ("y" ->> "qux") :: HNil)),
+          UpsertEvent.Commit("commit1"))
+
+      for {
+        tbl <- freshTableName
+        (values, offsets) <- consumer(tbl, toOpt(Column("x", ColumnType.String)), WriteMode.Replace, events)
+        } yield {
+          values must_== List(
+            "foo" :: "bar" :: HNil,
+            "baz" :: "qux" :: HNil)
+
+          offsets must_== List(OffsetKey.Actual.string("commit1"))
+        }
+    }
+
+//    "not write without a commit" >> appendAndUpsert[String :: String :: HNil] { (toOpt, consumer) =>
+//      val events =
+//        Stream(
+//          UpsertEvent.Create(List(("x" ->> "foo") :: ("y" ->> "bar") :: HNil)),
+//          UpsertEvent.Create(List(("x" ->> "quz") :: ("y" ->> "corge") :: HNil)),
+//          UpsertEvent.Commit("commit1"),
+//          UpsertEvent.Create(List(("x" ->> "baz") :: ("y" ->> "qux") :: HNil)))
+//
+//      for {
+//        tbl <- freshTableName
+//        (values, offsets) <- consumer(tbl, toOpt(Column("x", ColumnType.String)), WriteMode.Replace, events)
+//        } yield {
+//          values must_== List(
+//            "foo" :: "bar" :: HNil,
+//            "quz" :: "corge" :: HNil)
+//          offsets must_== List(OffsetKey.Actual.string("commit1"))
+//        }
+//    }
+
+    "commit twice in a row" >> appendAndUpsert[String :: String :: HNil] { (toOpt, consumer) =>
+      val events =
+        Stream(
+          UpsertEvent.Create(List(("x" ->> "foo") :: ("y" ->> "bar") :: HNil)),
+          UpsertEvent.Commit("commit1"),
+          UpsertEvent.Commit("commit2"))
+
+      for {
+        tbl <- freshTableName
+        (values, offsets) <- consumer(tbl, toOpt(Column("x", ColumnType.String)), WriteMode.Replace, events)
+        } yield {
+          values must_== List("foo" :: "bar" :: HNil)
+          offsets must_== List(
+            OffsetKey.Actual.string("commit1"),
+            OffsetKey.Actual.string("commit2"))
+        }
+    }
+
+    "upsert updates rows with string typed primary key on append" >>* {
+      Consumer.upsert[String :: String :: HNil](config(), TestConnectionUrl).use { consumer =>
+        val events =
+          Stream(
+            UpsertEvent.Create(
+              List(
+                ("x" ->> "foo") :: ("y" ->> "bar") :: HNil,
+                ("x" ->> "baz") :: ("y" ->> "qux") :: HNil)),
+            UpsertEvent.Commit("commit1"))
+
+        val append =
+          Stream(
+            UpsertEvent.Delete(Ids.StringIds(List("foo"))),
+            UpsertEvent.Create(
+              List(
+                ("x" ->> "foo") :: ("y" ->> "check0") :: HNil,
+                ("x" ->> "bar") :: ("y" ->> "check1") :: HNil)),
+            UpsertEvent.Commit("commit2"))
+
+        for {
+          tbl <- freshTableName
+          (values1, offsets1) <- consumer(tbl, Some(Column("x", ColumnType.String)), WriteMode.Replace, events)
+          (values2, offsets2) <- consumer(tbl, Some(Column("x", ColumnType.String)), WriteMode.Append, append)
+        } yield {
+          offsets1 must_== List(OffsetKey.Actual.string("commit1"))
+          offsets2 must_== List(OffsetKey.Actual.string("commit2"))
+          Set(values1:_*) must_== Set("foo" :: "bar" :: HNil, "baz" :: "qux" :: HNil)
+          Set(values2:_*) must_== Set("baz" :: "qux" :: HNil, "foo" :: "check0" :: HNil, "bar" :: "check1" :: HNil)
+        }
+      }
+    }
+
+    "upsert deletes rows with long typed primary key on append" >>* {
+      Consumer.upsert[Int :: String :: HNil](config(), TestConnectionUrl).use { consumer =>
+        val events =
+          Stream(
+            UpsertEvent.Create(
+              List(
+                ("x" ->> 40) :: ("y" ->> "bar") :: HNil,
+                ("x" ->> 42) :: ("y" ->> "qux") :: HNil)),
+            UpsertEvent.Commit("commit1"))
+
+        val append =
+          Stream(
+            UpsertEvent.Delete(Ids.LongIds(List(40))),
+            UpsertEvent.Create(
+              List(
+                ("x" ->> 40) :: ("y" ->> "check") :: HNil)),
+            UpsertEvent.Commit("commit2"))
+
+        for {
+          tbl <- freshTableName
+          (values1, offsets1) <- consumer(tbl, Some(Column("x", ColumnType.Number)), WriteMode.Replace, events)
+          (values2, offsets2) <- consumer(tbl, Some(Column("x", ColumnType.Number)), WriteMode.Append, append)
+        } yield {
+          Set(values1:_*) must_== Set(40 :: "bar" :: HNil, 42 :: "qux" :: HNil)
+          Set(values2:_*) must_== Set(40 :: "check" :: HNil, 42 :: "qux" :: HNil)
+          offsets1 must_== List(OffsetKey.Actual.string("commit1"))
+          offsets2 must_== List(OffsetKey.Actual.string("commit2"))
+        }
+      }
+    }
+
+    "upsert empty deletes without failing" >>* {
+      Consumer.upsert[String :: String :: HNil](config(), TestConnectionUrl).use { consumer =>
+        val events =
+          Stream(
+            UpsertEvent.Create(
+              List(
+                ("x" ->> "foo") :: ("y" ->> "bar") :: HNil,
+                ("x" ->> "baz") :: ("y" ->> "qux") :: HNil)),
+            UpsertEvent.Commit("commit1"),
+            UpsertEvent.Delete(Ids.StringIds(List())),
+            UpsertEvent.Commit("commit2"))
+
+        for {
+          tbl <- freshTableName
+          (values, offsets) <- consumer(tbl, Some(Column("x", ColumnType.String)), WriteMode.Replace, events)
+        } yield {
+          values must_== List(
+            "foo" :: "bar" :: HNil,
+            "baz" :: "qux" :: HNil)
+
+          offsets must_== List(
+            OffsetKey.Actual.string("commit1"),
+            OffsetKey.Actual.string("commit2"))
+        }
+      }
+    }
+
+    "creates table and then appends" >> appendAndUpsert[String :: String :: HNil] { (toOpt, consumer) =>
+      val events1 =
+        Stream(
+          UpsertEvent.Create(List(("x" ->> "foo") :: ("y" ->> "bar") :: HNil)),
+          UpsertEvent.Commit("commit1"))
+
+      val events2 =
+        Stream(
+          UpsertEvent.Create(List(("x" ->> "bar") :: ("y" ->> "qux") :: HNil)),
+          UpsertEvent.Commit("commit2"))
+
+      for {
+        tbl <- freshTableName
+
+        _ <- consumer(tbl, toOpt(Column("x", ColumnType.String)), WriteMode.Replace, events1)
+
+        (values, _) <- consumer(tbl, Some(Column("x", ColumnType.String)), WriteMode.Append, events2)
+        } yield {
+          values must_== List(
+            "foo" :: "bar" :: HNil,
+            "bar" :: "qux" :: HNil)
+        }
+    }
+}
+
+  "csv sink" should {
+    "reject empty paths with NotAResource" >>* {
+      csv(config()) { sink =>
+        val p = ResourcePath.root()
+        val (_, pipe) = sink.consume(p, NonEmptyList.one(Column("a", ColumnType.Boolean)))
+        val r = pipe(Stream.empty).compile.drain
+
+        MRE.attempt(r).map(_ must beLike {
+          case -\/(ResourceError.NotAResource(p2)) => p2 must_=== p
+        })
+      }
+    }
+
+    "reject paths with > 1 segments with NotAResource" >>* {
+      csv(config()) { sink =>
+        val p = ResourcePath.root() / ResourceName("foo") / ResourceName("bar")
+        val (_, pipe) = sink.consume(p, NonEmptyList.one(Column("a", ColumnType.Boolean)))
+        val r = pipe(Stream.empty).compile.drain
+
+        MRE.attempt(r).map(_ must beLike {
+          case -\/(ResourceError.NotAResource(p2)) => p2 must_=== p
+        })
+      }
+    }
+
+    "reject OffsetDate columns" >>* {
+      val MinOffsetDate = OffsetDate(LocalDate.MIN, ZoneOffset.MIN)
+      val MaxOffsetDate = OffsetDate(LocalDate.MAX, ZoneOffset.MAX)
+
+      freshTableName flatMap { table =>
+        val cfg = config(url = TestConnectionUrl)
+        val rs = Stream(("min" ->> MinOffsetDate) :: ("max" ->> MaxOffsetDate) :: HNil)
+
+        csv(cfg)(drainAndSelectAs[IO, String :: String :: HNil](TestConnectionUrl, table, _, rs))
+          .attempt
+          .map(_ must beLeft.like {
+            case ColumnTypesNotSupported(ts) => ts.toList must contain(ColumnType.OffsetDate: ColumnType)
+          })
+      }
+    }
+
+    "quote table names to prevent injection" >>* {
+      csv(config()) { sink =>
+        val recs = List(("x" ->> 2.3) :: ("y" ->> 8.1) :: HNil)
+
+        drainAndSelect(
+          TestConnectionUrl,
+          "foobar; drop table really_important; create table haha",
+          sink,
+          Stream.emits(recs)
+        ).map(_ must_=== recs)
+      }
+    }
+
+    "support table names containing double quote" >>* {
+      csv(config()) { sink =>
+        val recs = List(("x" ->> 934.23) :: ("y" ->> 1234424.123456) :: HNil)
+
+        drainAndSelect(
+          TestConnectionUrl,
+          """the "table" name""",
+          sink,
+          Stream.emits(recs)
+        ).map(_ must_=== recs)
+      }
+    }
+
+    "quote column names to prevent injection" >>* {
+      mustRoundtrip(("from nowhere; drop table super_mission_critical; select *" ->> 42) :: HNil)
+    }
+
+    "support columns names containing a double quote" >>* {
+      mustRoundtrip(("""the "column" name""" ->> 76) :: HNil)
+    }
+
+    "create an empty table when input is empty" >>* {
+      csv(config()) { sink =>
+        type R = Record.`"a" -> String, "b" -> Int, "c" -> LocalDate`.T
+
+        for {
+          tbl <- freshTableName
+          r <- drainAndSelect(TestConnectionUrl, tbl, sink, Stream.empty.covaryAll[IO, R])
+        } yield r must beEmpty
+      }
+    }
+
+    "create a row for each line of input" >>* mustRoundtrip(
+      ("foo" ->> 1) :: ("bar" ->> "baz1") :: ("quux" ->> 34.34234) :: HNil,
+      ("foo" ->> 2) :: ("bar" ->> "baz2") :: ("quux" ->> 35.34234) :: HNil,
+      ("foo" ->> 3) :: ("bar" ->> "baz3") :: ("quux" ->> 36.34234) :: HNil)
+
+
+    "roundtrip Boolean" >>* mustRoundtrip(("min" ->> true) :: ("max" ->> false) :: HNil)
+    "roundtrip Short" >>* mustRoundtrip(("min" ->> Short.MinValue) :: ("max" ->> Short.MaxValue) :: HNil)
+    "roundtrip Int" >>* mustRoundtrip(("min" ->> Int.MinValue) :: ("max" ->> Int.MaxValue) :: HNil)
+
+    "roundtrip String" >>* {
+      IO(scala.util.Random.nextString(32)) flatMap { s =>
+        mustRoundtrip(("value" ->> s) :: HNil)
+      }
+    }
+  }
+
+  val DM = RedshiftDestinationModule
+
+  val TestConnectionUrl: String =
+    scala.sys.env.get("REDSHIFT_JDBC") getOrElse ""
+
+  val TestBucket: String =
+    scala.sys.env.get("REDSHIFT_BUCKET") getOrElse ""
+
+  val TestAccessKey: String =
+    scala.sys.env.get("REDSHIFT_ACCESS_KEY") getOrElse ""
+
+  val TestSecretKey: String =
+    scala.sys.env.get("REDSHIFT_SECRET_KEY") getOrElse ""
+
+  val TestRegion: String =
+    scala.sys.env.get("REDSHIFT_REGION") getOrElse ""
+
+  val User: String =
+    scala.sys.env.get("REDSHIFT_USER") getOrElse ""
+
+  val Password: String =
+    scala.sys.env.get("REDSHIFT_PASSWORD") getOrElse ""
+
+  def testsEnabled: Boolean =
+    List(TestConnectionUrl, TestBucket, TestAccessKey, TestSecretKey, TestRegion, User, Password)
+      .forall(x => x =!= "")
+
+  implicit val CS: ContextShift[IO] = IO.contextShift(global)
+
+  implicit val TM: Timer[IO] = IO.timer(global)
+
+  implicit val MRE: MonadError_[IO, ResourceError] =
+    MonadError_.facet[IO](ResourceError.throwableP)
+
+  object renderRow extends renderForCsv(DM.RedshiftRenderConfig)
+
+  def hygienicIdent(s: String): String =
+    RedshiftFlow.escape(s)
+
+  def randomAlphaNum[F[_]: Sync](size: Int): F[String] =
+    Sync[F].delay(Random.alphanumeric.take(size).mkString)
+
+  val freshTableName: IO[String] =
+    randomAlphaNum[IO](6).map(suffix => s"redshift_test${suffix}")
+
+  def runDb[F[_]: Async: ContextShift, A](fa: ConnectionIO[A], uri: String = TestConnectionUrl): F[A] =
+    fa.transact(Transactor.fromDriverManager[F]("com.amazon.redshift.jdbc42.Driver", s"$uri;UID=$User;PWD=$Password"))
+
+  def config(url: String = TestConnectionUrl, schema: Option[String] = None): Json =
+    ("jdbcUri" := url) ->:
+    ("bucket" :=
+      ("bucket" := TestBucket) ->:
+        ("accessKey" := TestAccessKey) ->:
+        ("secretKey" := TestSecretKey) ->:
+      ("region" := TestRegion) ->:
+      jEmptyObject) ->:
+    ("password" := Password) ->:
+    ("user" := User) ->:
+    ("authorization" :=
+      ("type" := "keys") ->:
+        ("accessKey" := TestAccessKey) ->:
+        ("secretKey" := TestSecretKey) ->:
+      ("region" := TestRegion) ->:
+      jEmptyObject) ->:
+    jEmptyObject
+
+  def csv[A](cfg: Json)(f: ResultSink.CreateSink[IO, ColumnType.Scalar, Byte] => IO[A]): IO[A] =
+    dest(cfg) {
+      case Left(err) =>
+        IO.raiseError(new RuntimeException(err.shows))
+
+      case Right(dst) =>
+        dst.sinks.toList
+          .collectFirst { case c @ ResultSink.CreateSink(_) => c }
+          .map(s => f(s.asInstanceOf[ResultSink.CreateSink[IO, ColumnType.Scalar, Byte]]))
+          .getOrElse(IO.raiseError(new RuntimeException("No CSV sink found!")))
+    }
+
+  def upsertCsv[A](cfg: Json)(f: ResultSink.UpsertSink[IO, ColumnType.Scalar, Byte] => IO[A]): IO[A] =
+    dest(cfg) {
+      case Left(err) =>
+        IO.raiseError(new RuntimeException(err.shows))
+
+      case Right(dst) =>
+        dst.sinks.toList
+          .collectFirst { case c @ ResultSink.UpsertSink(_) => c }
+          .map(s => f(s.asInstanceOf[ResultSink.UpsertSink[IO, ColumnType.Scalar, Byte]]))
+          .getOrElse(IO.raiseError(new RuntimeException("No upsert CSV sink found!")))
+    }
+
+  def appendSink[A](cfg: Json)(f: ResultSink.AppendSink[IO, ColumnType.Scalar] => IO[A]): IO[A] =
+    dest(cfg) {
+      case Left(err) =>
+        IO.raiseError(new RuntimeException(err.shows))
+
+      case Right(dst) =>
+        dst.sinks.toList
+          .collectFirst { case c @ ResultSink.AppendSink(_) => c }
+          .map(s => f(s.asInstanceOf[ResultSink.AppendSink[IO, ColumnType.Scalar]]))
+          .getOrElse(IO.raiseError(new RuntimeException("No append CSV sink found!")))
+    }
+
+  def dest[A](cfg: Json)(f: Either[DM.InitErr, Destination[IO]] => IO[A]): IO[A] =
+    DM.destination[IO](cfg, _ => _ => Stream.empty).use(f)
+
+  trait Consumer[A]{
+    def apply[R <: HList, K <: HList, V <: HList, T <: HList, S <: HList](
+        table: String,
+        idColumn: Option[Column[ColumnType.Scalar]],
+        writeMode: WriteMode,
+        records: Stream[IO, UpsertEvent[R]])(
+        implicit
+        read: Read[A],
+        keys: Keys.Aux[R, K],
+        values: Values.Aux[R, V],
+        getTypes: Mapper.Aux[asColumnType.type, V, T],
+        rrow: Mapper.Aux[renderRow.type, V, S],
+        ktl: ToList[K, String],
+        vtl: ToList[S, String],
+        ttl: ToList[T, ColumnType.Scalar])
+        : IO[(List[A], List[OffsetKey.Actual[String]])]
+  }
+
+  object Consumer {
+    def upsert[A](cfg: Json, connectionUri: String): Resource[IO, Consumer[A]] = {
+      val rsink: Resource[IO, ResultSink.UpsertSink[IO, ColumnType.Scalar, Byte]] =
+        DM.destination[IO](cfg, _ => _ => Stream.empty) evalMap {
+          case Left(err) =>
+            IO.raiseError(new RuntimeException(err.shows))
+          case Right(dst) =>
+            val optSink = dst.sinks.toList.collectFirst { case c @ ResultSink.UpsertSink(_) => c }
+            optSink match {
+              case Some(s) => s.asInstanceOf[ResultSink.UpsertSink[IO, ColumnType.Scalar, Byte]].pure[IO]
+              case None => IO.raiseError(new RuntimeException("No upsert sink found"))
+            }
+        }
+      rsink map { sink => new Consumer[A] {
+        def apply[R <: HList, K <: HList, V <: HList, T <: HList, S <: HList](
+            table: String,
+            idColumn: Option[Column[ColumnType.Scalar]],
+            writeMode: WriteMode,
+            records: Stream[IO, UpsertEvent[R]])(
+            implicit
+            read: Read[A],
+            keys: Keys.Aux[R, K],
+            values: Values.Aux[R, V],
+            getTypes: Mapper.Aux[asColumnType.type, V, T],
+            rrow: Mapper.Aux[renderRow.type, V, S],
+            ktl: ToList[K, String],
+            vtl: ToList[S, String],
+            ttl: ToList[T, ColumnType.Scalar])
+            : IO[(List[A], List[OffsetKey.Actual[String]])] =
+        for {
+          tableColumns <- columnsOf(records, renderRow, idColumn).compile.lastOrError
+
+          colList = (idColumn.get :: tableColumns).map(k =>
+            Fragment.const(hygienicIdent(k.name))).intercalate(fr",")
+
+          dst = ResourcePath.root() / ResourceName(table)
+
+          offsets <- toUpsertCsvSink(
+            dst, sink, idColumn.get, writeMode, renderRow, records).compile.toList
+
+          q = fr"SELECT" ++ colList ++ fr"FROM" ++ Fragment.const(hygienicIdent(table))
+
+          rows <- runDb[IO, List[A]](q.query[A].to[List], connectionUri)
+
+        } yield (rows, offsets)
+      }}
+    }
+
+    def append[A](cfg: Json, connectionUri: String): Resource[IO, Consumer[A]] = {
+      val rsink: Resource[IO, ResultSink.AppendSink[IO, ColumnType.Scalar]] =
+        DM.destination[IO](cfg, _ => _ => Stream.empty) evalMap {
+          case Left(err) =>
+            IO.raiseError(new RuntimeException(err.shows))
+          case Right(dst) =>
+            val optSink = dst.sinks.toList.collectFirst { case c @ ResultSink.AppendSink(_) => c }
+            optSink match {
+              case Some(s) => s.asInstanceOf[ResultSink.AppendSink[IO, ColumnType.Scalar]].pure[IO]
+              case None => IO.raiseError(new RuntimeException("No append sink found"))
+            }
+        }
+      rsink map { sink => new Consumer[A] {
+        def apply[R <: HList, K <: HList, V <: HList, T <: HList, S <: HList](
+            table: String,
+            idColumn: Option[Column[ColumnType.Scalar]],
+            writeMode: WriteMode,
+            records: Stream[IO, UpsertEvent[R]])(
+            implicit
+            read: Read[A],
+            keys: Keys.Aux[R, K],
+            values: Values.Aux[R, V],
+            getTypes: Mapper.Aux[asColumnType.type, V, T],
+            rrow: Mapper.Aux[renderRow.type, V, S],
+            ktl: ToList[K, String],
+            vtl: ToList[S, String],
+            ttl: ToList[T, ColumnType.Scalar])
+            : IO[(List[A], List[OffsetKey.Actual[String]])] =
+        for {
+          tableColumns <- columnsOf(records, renderRow, idColumn).compile.lastOrError
+
+          colList = (idColumn.toList ++ tableColumns).map(k =>
+            Fragment.const(hygienicIdent(k.name))).intercalate(fr",")
+
+          dst = ResourcePath.root() / ResourceName(table)
+
+          offsets <- toAppendCsvSink(
+            dst, sink, idColumn, writeMode, renderRow, records).compile.toList
+
+          q = fr"SELECT" ++ colList ++ fr"FROM" ++ Fragment.const(hygienicIdent(table))
+
+          rows <- runDb[IO, List[A]](q.query[A].to[List], connectionUri)
+
+        } yield (rows, offsets)
+      }
+    }}
+  }
+
+  object appendAndUpsert {
+    def apply[A]: PartiallyApplied[A] = new PartiallyApplied[A]
+
+    final class PartiallyApplied[A] {
+      type MkOption = Column[ColumnType.Scalar] => Option[Column[ColumnType.Scalar]]
+      def apply[R: AsResult](
+          f: (MkOption, Consumer[A]) => IO[R])
+          : SFragment = {
+        "upsert" >>* Consumer.upsert[A](config(), TestConnectionUrl).use(f(Some(_), _))
+        "append" >>* Consumer.append[A](config(), TestConnectionUrl).use(f(Some(_), _))
+        "no-id" >>* Consumer.append[A](config(), TestConnectionUrl).use(f(x => None, _))
+      }
+    }
+  }
+
+  object idOnly {
+    def apply[A]: PartiallyApplied[A] = new PartiallyApplied[A]
+
+    final class PartiallyApplied[A] {
+      type MkOption = Column[ColumnType.Scalar] => Option[Column[ColumnType.Scalar]]
+      def apply[R: AsResult](
+          f: (MkOption, Consumer[A]) => IO[R])
+          : SFragment = {
+        "upsert" >>* Consumer.upsert[A](config(), TestConnectionUrl).use(f(Some(_), _))
+        "append" >>* Consumer.append[A](config(), TestConnectionUrl).use(f(Some(_), _))
+      }
+    }
+  }
+
+  def drainAndSelect[F[_]: Async: ContextShift, R <: HList, K <: HList, V <: HList, T <: HList, S <: HList](
+      connectionUri: String,
+      table: String,
+      sink: ResultSink.CreateSink[F, ColumnType.Scalar, Byte],
+      records: Stream[F, R],
+      schema: String = "public")(
+      implicit
+      keys: Keys.Aux[R, K],
+      values: Values.Aux[R, V],
+      read: Read[V],
+      getTypes: Mapper.Aux[asColumnType.type, V, T],
+      rrow: Mapper.Aux[renderRow.type, V, S],
+      ktl: ToList[K, String],
+      vtl: ToList[S, String],
+      ttl: ToList[T, ColumnType.Scalar])
+      : F[List[V]] =
+    drainAndSelectAs[F, V](connectionUri, table, sink, records, schema)
+
+  object drainAndSelectAs {
+    def apply[F[_], A]: PartiallyApplied[F, A] =
+      new PartiallyApplied[F, A]
+
+    final class PartiallyApplied[F[_], A]() {
+      def apply[R <: HList, K <: HList, V <: HList, T <: HList, S <: HList](
+          connectionUri: String,
+          table: String,
+          sink: ResultSink.CreateSink[F, ColumnType.Scalar, Byte],
+          records: Stream[F, R],
+          schema: String = "public")(
+          implicit
+          async: Async[F],
+          cshift: ContextShift[F],
+          read: Read[A],
+          keys: Keys.Aux[R, K],
+          values: Values.Aux[R, V],
+          getTypes: Mapper.Aux[asColumnType.type, V, T],
+          rrow: Mapper.Aux[renderRow.type, V, S],
+          ktl: ToList[K, String],
+          vtl: ToList[S, String],
+          ttl: ToList[T, ColumnType.Scalar])
+          : F[List[A]] = {
+
+        val dst = ResourcePath.root() / ResourceName(table)
+
+        val go = records.pull.peek1 flatMap {
+          case Some((r, rs)) =>
+            val colList =
+              r.keys.toList
+                .map(k => Fragment.const(hygienicIdent(k)))
+                .intercalate(fr",")
+
+            val createSchema = fr"CREATE SCHEMA IF NOT EXISTS" ++
+              Fragment.const(hygienicIdent(schema))
+
+            val q = fr"SELECT" ++
+              colList ++
+              fr"FROM" ++
+              Fragment.const(hygienicIdent(schema)) ++
+              fr0"." ++
+              Fragment.const(hygienicIdent(table))
+
+            val run = for {
+              _ <- runDb[F, Int](createSchema.update.run, connectionUri)
+              _ <- toCsvSink(dst, sink, renderRow, rs).compile.drain
+              rows <- runDb[F, List[A]](q.query[A].to[List], connectionUri)
+            } yield rows
+
+            Pull.eval(run).flatMap(Pull.output1)
+
+          case None =>
+            Pull.done
+        }
+
+        go.stream.compile.last.map(_ getOrElse Nil)
+      }
+    }
+  }
+
+  def loadAndRetrieve[R <: HList, K <: HList, V <: HList, T <: HList, S <: HList](
+      record: R,
+      records: R*)(
+      implicit
+      keys: Keys.Aux[R, K],
+      values: Values.Aux[R, V],
+      read: Read[V],
+      getTypes: Mapper.Aux[asColumnType.type, V, T],
+      rrow: Mapper.Aux[renderRow.type, V, S],
+      ktl: ToList[K, String],
+      vtl: ToList[S, String],
+      ttl: ToList[T, ColumnType.Scalar])
+      : IO[List[V]] =
+    randomAlphaNum[IO](6) flatMap { tableSuffix =>
+      val table = s"redshift_dest_test${tableSuffix}"
+      val cfg = config(url = TestConnectionUrl)
+      val rs = record +: records
+
+      csv(cfg)(drainAndSelect(TestConnectionUrl, table, _, Stream.emits(rs)))
+    }
+
+  def mustRoundtrip[R <: HList, K <: HList, V <: HList, T <: HList, S <: HList](
+      record: R,
+      records: R*)(
+      implicit
+      keys: Keys.Aux[R, K],
+      values: Values.Aux[R, V],
+      read: Read[V],
+      getTypes: Mapper.Aux[asColumnType.type, V, T],
+      rrow: Mapper.Aux[renderRow.type, V, S],
+      ktl: ToList[K, String],
+      vtl: ToList[S, String],
+      ttl: ToList[T, ColumnType.Scalar])
+      : IO[MatchResult[List[V]]] =
+    loadAndRetrieve(record, records: _*)
+      .map(_ must containTheSameElementsAs(record +: records))
+}

--- a/core/src/test/scala/quasar/destination/redshift/RedshiftDestinationSpec.scala
+++ b/core/src/test/scala/quasar/destination/redshift/RedshiftDestinationSpec.scala
@@ -382,25 +382,25 @@ object RedshiftDestinationSpec extends EffectfulQSpec[IO] with CsvSupport {
 
   val DM = RedshiftDestinationModule
 
-  val TestConnectionUrl: String =
+  def TestConnectionUrl: String =
     scala.sys.env.get("REDSHIFT_JDBC") getOrElse ""
 
-  val TestBucket: String =
+  def TestBucket: String =
     scala.sys.env.get("REDSHIFT_BUCKET") getOrElse ""
 
-  val TestAccessKey: String =
+  def TestAccessKey: String =
     scala.sys.env.get("REDSHIFT_ACCESS_KEY") getOrElse ""
 
-  val TestSecretKey: String =
+  def TestSecretKey: String =
     scala.sys.env.get("REDSHIFT_SECRET_KEY") getOrElse ""
 
-  val TestRegion: String =
+  def TestRegion: String =
     scala.sys.env.get("REDSHIFT_REGION") getOrElse ""
 
-  val User: String =
+  def User: String =
     scala.sys.env.get("REDSHIFT_USER") getOrElse ""
 
-  val Password: String =
+  def Password: String =
     scala.sys.env.get("REDSHIFT_PASSWORD") getOrElse ""
 
   def testsEnabled: Boolean =


### PR DESCRIPTION
[ch13168], `DECIMAL(21, 6)` for numerics and sanitizing configs in errors.

Stream framing is a bit different with gbq dest, instead of accumulating chunks in queues and emit streams on delete|commit, it emits stream when the first chunk appears and puts data into the  queue in background, no `Resource` because finalization happens in different fiber and so on. 

I'll address commented test in https://app.clubhouse.io/data/story/13170/destination-types if you don't mind, can't come up with fast and clean solution. We could utilize `autocommit=false` or accumulate staged files and copy them on commit (I like the 2nd option more). 